### PR TITLE
Hp threshold and fractional scaling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.1'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyConfig.java
+++ b/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyConfig.java
@@ -15,10 +15,10 @@ public interface ProtectItemNotifyConfig extends Config
 	default int hpthreshold() {return 0;}
 	@ConfigItem(
 			keyName = "scale",
-			name = "Scale",
+			name = "Scale %",
 			description = "The scale of the ring of protect item image.")
 	default int scale() {
-		return 1;
+		return 100;
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyConfig.java
+++ b/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyConfig.java
@@ -8,6 +8,12 @@ import net.runelite.client.config.ConfigItem;
 public interface ProtectItemNotifyConfig extends Config
 {
 	@ConfigItem(
+			keyName = "hpthreshold",
+			name = "Hp Threshold",
+			description = "If your current health falls below this value you will be notified. Set to 0 to disable."
+	)
+	default int hpthreshold() {return 0;}
+	@ConfigItem(
 			keyName = "scale",
 			name = "Scale",
 			description = "The scale of the ring of protect item image.")

--- a/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyOverlay.java
+++ b/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyOverlay.java
@@ -46,6 +46,10 @@ public class ProtectItemNotifyOverlay extends Overlay {
             return null;
         }
 
+        if (plugin.getHealth() >= protectItemConfig.hpthreshold() || protectItemConfig.hpthreshold() == 0) {
+            return null;
+        }
+
         if (!plugin.isProtectItemOn()) {
             return null;
         }

--- a/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyOverlay.java
+++ b/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyOverlay.java
@@ -67,9 +67,9 @@ public class ProtectItemNotifyOverlay extends Overlay {
         int h = protectItemImage.getHeight();
         BufferedImage scaledProtectItemImage =
                 new BufferedImage(
-                        protectItemConfig.scale() * w, protectItemConfig.scale() * h, BufferedImage.TYPE_INT_ARGB);
+                        Math.round(protectItemConfig.scale()/100.0f * w), Math.round(protectItemConfig.scale()/100.0f * h), BufferedImage.TYPE_INT_ARGB);
         AffineTransform at = new AffineTransform();
-        at.scale(protectItemConfig.scale(), protectItemConfig.scale());
+        at.scale(protectItemConfig.scale()/100.0f, protectItemConfig.scale()/100.0f);
         AffineTransformOp scaleOp = new AffineTransformOp(at, AffineTransformOp.TYPE_BILINEAR);
         scaledProtectItemImage = scaleOp.filter(protectItemImage, scaledProtectItemImage);
         previouslyScaledImage.scaledBufferedImage = scaledProtectItemImage;

--- a/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyPlugin.java
+++ b/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyPlugin.java
@@ -5,17 +5,13 @@ import com.protectItemNotify.ProtectItemNotify.ProtectItemNotifyOverlay;
 import java.util.Optional;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.InventoryID;
-import net.runelite.api.ItemContainer;
-import net.runelite.api.Prayer;
+import net.runelite.api.*;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
-import net.runelite.api.Varbits;
 
 @Slf4j
 @PluginDescriptor(
@@ -59,5 +55,9 @@ public class ProtectItemNotifyPlugin extends Plugin
 
 	public boolean isProtectItemOn() {
 		return protectItemOn;
+	}
+
+	public int getHealth() {
+		return client.getRealSkillLevel(Skill.HITPOINTS);
 	}
 }

--- a/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyPlugin.java
+++ b/src/main/java/com/protectItemNotify/ProtectItemNotify/ProtectItemNotifyPlugin.java
@@ -1,11 +1,12 @@
 package com.protectItemNotify.ProtectItemNotify;
 
 import com.google.inject.Provides;
-import com.protectItemNotify.ProtectItemNotify.ProtectItemNotifyOverlay;
-import java.util.Optional;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.*;
+import net.runelite.api.Client;
+import net.runelite.api.Prayer;
+import net.runelite.api.Varbits;
+import net.runelite.api.Skill;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;


### PR DESCRIPTION
The first change is a new feature for HP threshold. If set to 0 the hp threshold is unused. If the value is not 0 then the notifier will show only when the player's HP falls strictly below the threshold value.

The second change is allowing the player to specify a scale percentage. Before, scale took only an integer value. The image was large at scale == 1 at 150x150 pixels. Now a player can enter a scale percentage of 50 to get the notifier image down to 75x75 pixels. 

Both changes are small quality of life changes.